### PR TITLE
Add start parameter limiter

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,6 +34,13 @@ var validateRequest = function (request, options) {
       }
     }
 
+    if (paramPrefix === 'start') {
+      var start = +p[1]
+      if (start > options.maxStart) {
+        return true
+      }
+    }
+
     return options.invalidParams.indexOf(paramPrefix) !== -1
   })) {
     return false
@@ -51,7 +58,8 @@ var defaultOptions = {
     host: 'localhost',
     port: 8080
   },
-  maxRows: 200
+  maxRows: 200,
+  maxStart: 1000
 }
 
 var createServer = function (options) {

--- a/lib/cli/argv.js
+++ b/lib/cli/argv.js
@@ -27,6 +27,10 @@ var createProxyOptions = function (argv) {
     proxyOptions.maxRows = +argv.maxRows
   }
 
+  if (+argv.maxStart) {
+    proxyOptions.maxStart = +argv.maxStart
+  }
+
   return proxyOptions
 }
 
@@ -43,6 +47,7 @@ module.exports = function (argv, stdout, SolrProxy) {
     '  --validMethods   Allowed HTTP methods (comma         [default: "GET"]\n' +
     '                   delimited)\n' +
     '  --maxRows        Maximum rows permitted in a request [default: 200]\n' +
+    '  --maxStart       Maximum start offset permitted in a request [default: 1000]\n' +
     '  --quiet, -q      Do not write messages to STDOUT\n' +
     '  --version, -v    Show version\n' +
     '  --help, -h       Show this message'

--- a/test/index.js
+++ b/test/index.js
@@ -240,7 +240,7 @@ describe('proxy server start', function () {
 
   it('should return 200 if start param does not exceed maximum', async function () {
     solrTestDouble = createSolrTestDouble(200)
-    await checkResponseCode(http, 'http://localhost:8008/solr/select?q=fhqwhagads&start=100', 200)
+    await checkResponseCode(http, 'http://localhost:8008/solr/select?q=fhqwhagads&start=1001', 200)
   })
 
   it('should return 200 if start param is unspecified', async function () {

--- a/test/index.js
+++ b/test/index.js
@@ -161,14 +161,29 @@ describe('proxy server defaults', function () {
     await checkResponseCode(http, 'http://localhost:8008/solr/select?q=fhqwhagads&rows=201', 403)
   })
 
+  it('should return 403 if start param exceeds 1000 default', async function () {
+    solrTestDouble = createSolrTestDouble(200)
+    await checkResponseCode(http, 'http://localhost:8008/solr/select?q=fhqwhagads&start=1001', 403)
+  })
+
   it('should return 200 if rows param does not exceed 200 default', async function () {
     solrTestDouble = createSolrTestDouble(200)
     await checkResponseCode(http, 'http://localhost:8008/solr/select?q=fhqwhagads&rows=199', 200)
   })
 
+  it('should return 200 if start param does not exceed 1000 default', async function () {
+    solrTestDouble = createSolrTestDouble(200)
+    await checkResponseCode(http, 'http://localhost:8008/solr/select?q=fhqwhagads&start=999', 200)
+  })
+
   it('should return permit the query if rows param is not an integer', async function () {
     solrTestDouble = createSolrTestDouble(200)
     await checkResponseCode(http, 'http://localhost:8008/solr/select?q=fhqwhagads&rows=foobar', 200)
+  })
+
+  it('should return permit the query if start param is not an integer', async function () {
+    solrTestDouble = createSolrTestDouble(200)
+    await checkResponseCode(http, 'http://localhost:8008/solr/select?q=fhqwhagads&start=foobar', 200)
   })
 })
 
@@ -198,6 +213,37 @@ describe('proxy server rows', function () {
   })
 
   it('should return 200 if rows param is unspecified', async function () {
+    solrTestDouble = createSolrTestDouble(200)
+    await checkResponseCode(http, 'http://localhost:8008/solr/select?q=fhqwhagads', 200)
+  })
+})
+
+describe('proxy server start', function () {
+  var proxy
+  var solrTestDouble
+
+  beforeEach(function () {
+    proxy = SolrProxy.start(null, { maxStart: 1000 })
+  })
+
+  afterEach(function () {
+    proxy.close()
+    if (solrTestDouble.close) {
+      solrTestDouble.close()
+    }
+  })
+
+  it('should return 403 if start param exceeds maximum', async function () {
+    solrTestDouble = createSolrTestDouble(200)
+    await checkResponseCode(http, 'http://localhost:8008/solr/select?q=fhqwhagads&start=1001', 403)
+  })
+
+  it('should return 200 if ssstart param does not exceed maximum', async function () {
+    solrTestDouble = createSolrTestDouble(200)
+    await checkResponseCode(http, 'http://localhost:8008/solr/select?q=fhqwhagads&start=100', 200)
+  })
+
+  it('should return 200 if start param is unspecified', async function () {
     solrTestDouble = createSolrTestDouble(200)
     await checkResponseCode(http, 'http://localhost:8008/solr/select?q=fhqwhagads', 200)
   })

--- a/test/index.js
+++ b/test/index.js
@@ -223,7 +223,7 @@ describe('proxy server start', function () {
   var solrTestDouble
 
   beforeEach(function () {
-    proxy = SolrProxy.start(null, { maxStart: 1000 })
+    proxy = SolrProxy.start(null, { maxStart: 2000 })
   })
 
   afterEach(function () {
@@ -235,10 +235,10 @@ describe('proxy server start', function () {
 
   it('should return 403 if start param exceeds maximum', async function () {
     solrTestDouble = createSolrTestDouble(200)
-    await checkResponseCode(http, 'http://localhost:8008/solr/select?q=fhqwhagads&start=1001', 403)
+    await checkResponseCode(http, 'http://localhost:8008/solr/select?q=fhqwhagads&start=2001', 403)
   })
 
-  it('should return 200 if ssstart param does not exceed maximum', async function () {
+  it('should return 200 if start param does not exceed maximum', async function () {
     solrTestDouble = createSolrTestDouble(200)
     await checkResponseCode(http, 'http://localhost:8008/solr/select?q=fhqwhagads&start=100', 200)
   })

--- a/test/lib/cli/argv.js
+++ b/test/lib/cli/argv.js
@@ -100,7 +100,8 @@ describe('argv', function () {
             validHttpMethods: ['DELETE', 'PUT'],
             invalidParams: ['q'],
             validPaths: ['/come/on', '/fhqwhagads'],
-            maxRows: 100
+            maxRows: 100,
+            maxStart: 1000
           })
         }
       }
@@ -113,7 +114,8 @@ describe('argv', function () {
         validMethods: 'DELETE,PUT',
         invalidParams: 'q',
         validPaths: '/come/on,/fhqwhagads',
-        maxRows: 100
+        maxRows: 100,
+        maxStart: 1000
       }
 
       argv(argvStuff, noop, proxyTestDouble)


### PR DESCRIPTION
The value of the request "start" parameter should be also limited. The default limit is set to 1000. All tests pass now .