### PR TITLE
BREAKING CHANGE: use canonical Solr default port for backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Options are:
 ```
 Options:
   --port           Listen on this port                 [default: 8008]
-  --backendPort    Solr backend port                   [default: 8080]
+  --backendPort    Solr backend port                   [default: 8983]
   --backendHost    Solr backend host                   [default: "localhost"]
   --validPaths     Allowed paths (comma delimited)     [default: "/solr/select"]
   --invalidParams  Blocked parameters (comma           [default: "qt,stream"]

--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ const defaultOptions = {
   invalidParams: ['qt', 'stream'],
   backend: {
     host: 'localhost',
-    port: 8080
+    port: 8983
   },
   maxRows: 200,
   maxStart: 1000

--- a/lib/cli/argv.js
+++ b/lib/cli/argv.js
@@ -39,7 +39,7 @@ module.exports = function (argv, stdout, SolrProxy) {
     '\n' +
     'Options:\n' +
     '  --port           Listen on this port                 [default: 8008]\n' +
-    '  --backendPort    Solr backend port                   [default: 8080]\n' +
+    '  --backendPort    Solr backend port                   [default: 8983]\n' +
     '  --backendHost    Solr backend host                   [default: "localhost"]\n' +
     '  --validPaths     Allowed paths (comma delimited)     [default: "/solr/select"]\n' +
     '  --invalidParams  Blocked parameters (comma           [default: "qt,stream"]\n' +

--- a/test/index.js
+++ b/test/index.js
@@ -23,7 +23,7 @@ const createSolrTestDouble = function (responseCode) {
     res.writeHead(responseCode)
     res.end()
   })
-  return server.listen(8080)
+  return server.listen(8983)
 }
 
 const checkResponseCode = util.promisify(function (client, url, expectedCode, done) {
@@ -112,7 +112,7 @@ describe('proxy server defaults', function () {
       c.write('abc\r\n')
       c.end()
     })
-    solrTestDouble = server.listen(8080)
+    solrTestDouble = server.listen(8983)
     await checkResponseCode(http, 'http://localhost:8008/solr/select?q=fhqwhagads', 502)
   })
 


### PR DESCRIPTION
If the "backend" (i.e., Solr server) port is not specified, use the
default Solr port of 8983 rather than our own default of 8080.