### PR TITLE
chore: drop support for 10.x

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 15.x]
+        node-version: [12.x, 14.x, 15.x, 16.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "standard": "^16.0.0"
   },
   "engines": {
-    "node": ">=10.18.0"
+    "node": ">=12"
   },
   "license": "MIT",
   "release": {


### PR DESCRIPTION
BREAKING CHNAGE: drop support for Node.js 10.x