### PR TITLE
chore: remove debug dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,10 @@
 const httpProxy = require('http-proxy')
 const extend = require('xtend')
-const debug = require('debug')('solr-proxy')
+
+// To enable verbose logging, set environment variable:
+//
+// $ NODE_DEBUG=solr-proxy solr-proxy
+const debug = require('util').debuglog('solr-proxy')
 
 /*
  * Returns true if the request satisfies the following conditions:
@@ -61,6 +65,7 @@ const defaultOptions = {
 }
 
 const createServer = function (options) {
+  debug('Creating server with options: %j', options)
   const proxy = httpProxy.createProxyServer({ target: options.backend })
 
   proxy.on('error', function (err, req, res) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "6.0.1",
       "license": "MIT",
       "dependencies": {
-        "debug": "^4.1.1",
         "http-proxy": "^1.18.1",
         "minimist": "^1.2.0",
         "xtend": "^4.0.2"
@@ -1665,6 +1664,7 @@
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
       "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -4312,7 +4312,8 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -10398,6 +10399,7 @@
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
       "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "dev": true,
       "requires": {
         "ms": "2.1.2"
       }
@@ -12345,7 +12347,8 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
     },
     "natural-compare": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "url": "git://github.com/Trott/solr-proxy.git"
   },
   "dependencies": {
-    "debug": "^4.1.1",
     "http-proxy": "^1.18.1",
     "minimist": "^1.2.0",
     "xtend": "^4.0.2"


### PR DESCRIPTION
BREAKING_CHANGE: Use NODE_DEBUG=solr-proxy instead of DEBUG=solr-proxy
for verbose output.