### PR TITLE
chore: remove hapi/code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "solr-proxy": "bin/solr-proxy.js"
       },
       "devDependencies": {
-        "@hapi/code": "^8.0.7",
         "@hapi/lab": "^24.6.0",
         "@semantic-release/changelog": "^6.0.1",
         "@semantic-release/git": "^10.0.1",
@@ -450,15 +449,6 @@
       "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.1.0.tgz",
       "integrity": "sha512-i1BpaNDVLJdRBEKeJWkVO6tYX6DMFBuwMhSuWqLsY4ufeTKGVuV5rBsUhxPayXqnnWHgXUAmWK16H/ykO5Wj4Q==",
       "dev": true
-    },
-    "node_modules/@hapi/code": {
-      "version": "8.0.7",
-      "resolved": "https://registry.npmjs.org/@hapi/code/-/code-8.0.7.tgz",
-      "integrity": "sha512-4FTubqMVwbeMmmpxtmpdDz8xo24JQydAGNneGUDkj3lV6H7zUBPrufUvajFlTMZC7MdNV+apZImNJUIZt1gD/Q==",
-      "dev": true,
-      "dependencies": {
-        "@hapi/hoek": "9.x.x"
-      }
     },
     "node_modules/@hapi/eslint-plugin": {
       "version": "5.1.0",
@@ -10062,15 +10052,6 @@
       "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.1.0.tgz",
       "integrity": "sha512-i1BpaNDVLJdRBEKeJWkVO6tYX6DMFBuwMhSuWqLsY4ufeTKGVuV5rBsUhxPayXqnnWHgXUAmWK16H/ykO5Wj4Q==",
       "dev": true
-    },
-    "@hapi/code": {
-      "version": "8.0.7",
-      "resolved": "https://registry.npmjs.org/@hapi/code/-/code-8.0.7.tgz",
-      "integrity": "sha512-4FTubqMVwbeMmmpxtmpdDz8xo24JQydAGNneGUDkj3lV6H7zUBPrufUvajFlTMZC7MdNV+apZImNJUIZt1gD/Q==",
-      "dev": true,
-      "requires": {
-        "@hapi/hoek": "9.x.x"
-      }
     },
     "@hapi/eslint-plugin": {
       "version": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "minimist": "^1.2.0"
   },
   "devDependencies": {
-    "@hapi/code": "^8.0.7",
     "@hapi/lab": "^24.6.0",
     "@semantic-release/changelog": "^6.0.1",
     "@semantic-release/git": "^10.0.1",

--- a/test/bin/solr-proxy.d.ts.map
+++ b/test/bin/solr-proxy.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"solr-proxy.d.ts","sourceRoot":"","sources":["solr-proxy.ts"],"names":[],"mappings":"AACA,OAAO,GAAG,MAAM,WAAW,CAAA;AAG3B,QAAA,MAAM,GAAG,mBAAe,CAAA;AACxB,OAAO,EAAE,GAAG,EAAE,CAAA"}
+{"version":3,"file":"solr-proxy.d.ts","sourceRoot":"","sources":["solr-proxy.ts"],"names":[],"mappings":"AAAA,OAAO,GAAG,MAAM,WAAW,CAAA;AAI3B,QAAA,MAAM,GAAG,mBAAe,CAAA;AACxB,OAAO,EAAE,GAAG,EAAE,CAAA"}

--- a/test/bin/solr-proxy.js
+++ b/test/bin/solr-proxy.js
@@ -1,9 +1,8 @@
-import Code from '@hapi/code';
 import Lab from '@hapi/lab';
+import assert from 'node:assert';
 import childProcess from 'child_process';
 const lab = Lab.script();
 export { lab };
-const expect = Code.expect;
 const describe = lab.experiment;
 const it = lab.test;
 describe('CLI', function () {
@@ -16,9 +15,9 @@ describe('CLI', function () {
                 subprocess.kill('SIGINT');
             });
             subprocess.once('exit', function (code, signal) {
-                expect(output).to.equal('solr-proxy is running...\n');
-                expect(code).to.equal(null);
-                expect(signal).to.equal('SIGINT');
+                assert.strictEqual(output, 'solr-proxy is running...\n');
+                assert.strictEqual(code, null);
+                assert.strictEqual(signal, 'SIGINT');
                 resolve();
             });
         });

--- a/test/bin/solr-proxy.ts
+++ b/test/bin/solr-proxy.ts
@@ -1,11 +1,10 @@
-import Code from '@hapi/code'
 import Lab from '@hapi/lab'
+import assert from 'node:assert'
 import childProcess from 'child_process'
 
 const lab = Lab.script()
 export { lab }
 
-const expect = Code.expect
 const describe = lab.experiment
 const it = lab.test
 
@@ -19,9 +18,9 @@ describe('CLI', function () {
         subprocess.kill('SIGINT')
       })
       subprocess.once('exit', function (code, signal) {
-        expect(output).to.equal('solr-proxy is running...\n')
-        expect(code).to.equal(null)
-        expect(signal).to.equal('SIGINT')
+        assert.strictEqual(output, 'solr-proxy is running...\n')
+        assert.strictEqual(code, null)
+        assert.strictEqual(signal, 'SIGINT')
         resolve()
       })
     })

--- a/test/index.d.ts.map
+++ b/test/index.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"index.d.ts","sourceRoot":"","sources":["index.ts"],"names":[],"mappings":"AACA,OAAO,GAAG,MAAM,WAAW,CAAA;AAU3B,QAAA,MAAM,GAAG,mBAAe,CAAA;AACxB,OAAO,EAAE,GAAG,EAAE,CAAA"}
+{"version":3,"file":"index.d.ts","sourceRoot":"","sources":["index.ts"],"names":[],"mappings":"AAAA,OAAO,GAAG,MAAM,WAAW,CAAA;AAW3B,QAAA,MAAM,GAAG,mBAAe,CAAA;AACxB,OAAO,EAAE,GAAG,EAAE,CAAA"}

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,5 @@
-import Code from '@hapi/code';
 import Lab from '@hapi/lab';
+import assert from 'node:assert';
 import fs from 'node:fs';
 import http from 'node:http';
 import https from 'node:https';
@@ -8,7 +8,6 @@ import util from 'node:util';
 import SolrProxy from '../index.js';
 const lab = Lab.script();
 export { lab };
-const expect = Code.expect;
 const describe = lab.experiment;
 const it = lab.test;
 const beforeEach = lab.beforeEach;
@@ -26,13 +25,13 @@ const checkResponseCode = util.promisify(function (client, url, expectedCode, do
         rejectUnauthorized: false
     };
     client.get(parsed, options, (res) => {
-        expect(res.statusCode).to.equal(expectedCode);
+        assert.strictEqual(res.statusCode, expectedCode);
         done();
     });
 });
 describe('exports', function () {
     it('should expose a start function', function () {
-        expect(typeof SolrProxy.start).to.equal('function');
+        assert.strictEqual(typeof SolrProxy.start, 'function');
     });
 });
 describe('start()', function () {
@@ -57,7 +56,7 @@ describe('start()', function () {
                     reject(new Error('not supposed to get here'));
                 });
                 req.on('error', function (err) {
-                    expect(err.code).to.equal('ECONNREFUSED');
+                    assert.strictEqual(err.code, 'ECONNREFUSED');
                     resolve();
                 });
             });
@@ -116,7 +115,7 @@ describe('proxy server defaults', function () {
             method: 'POST'
         })
             .on('response', function (response) {
-            expect(response.statusCode).to.equal(404);
+            assert.strictEqual(response.statusCode, 404);
             done();
         })
             .end('{"q": "fhqwhgads"}');

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,6 +1,6 @@
-import Code from '@hapi/code'
 import Lab from '@hapi/lab'
 
+import assert from 'node:assert'
 import fs from 'node:fs'
 import http, { ServerResponse } from 'node:http'
 import https from 'node:https'
@@ -11,7 +11,6 @@ import SolrProxy from '../index.js'
 
 const lab = Lab.script()
 export { lab }
-const expect = Code.expect
 const describe = lab.experiment
 const it = lab.test
 const beforeEach = lab.beforeEach
@@ -32,14 +31,14 @@ const checkResponseCode = util.promisify(function (client: { get: Function }, ur
   }
 
   client.get(parsed, options, (res: ServerResponse) => {
-    expect(res.statusCode).to.equal(expectedCode)
+    assert.strictEqual(res.statusCode, expectedCode)
     done()
   })
 })
 
 describe('exports', function () {
   it('should expose a start function', function () {
-    expect(typeof SolrProxy.start).to.equal('function')
+    assert.strictEqual(typeof SolrProxy.start, 'function')
   })
 })
 
@@ -70,7 +69,7 @@ describe('start()', function () {
           reject(new Error('not supposed to get here'))
         })
         req.on('error', function (err: any) {
-          expect(err.code).to.equal('ECONNREFUSED')
+          assert.strictEqual(err.code, 'ECONNREFUSED')
           resolve()
         })
       })
@@ -138,7 +137,7 @@ describe('proxy server defaults', function () {
         method: 'POST'
       })
       .on('response', function (response) {
-        expect(response.statusCode).to.equal(404)
+        assert.strictEqual(response.statusCode, 404)
         done()
       })
       .end('{"q": "fhqwhgads"}')

--- a/test/lib/cli/argv.d.ts.map
+++ b/test/lib/cli/argv.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"argv.d.ts","sourceRoot":"","sources":["argv.ts"],"names":[],"mappings":"AAGA,OAAO,GAAG,MAAM,WAAW,CAAA;AAG3B,QAAA,MAAM,GAAG,mBAAe,CAAA;AACxB,OAAO,EAAE,GAAG,EAAE,CAAA"}
+{"version":3,"file":"argv.d.ts","sourceRoot":"","sources":["argv.ts"],"names":[],"mappings":"AAEA,OAAO,GAAG,MAAM,WAAW,CAAA;AAK3B,QAAA,MAAM,GAAG,mBAAe,CAAA;AACxB,OAAO,EAAE,GAAG,EAAE,CAAA"}

--- a/test/lib/cli/argv.js
+++ b/test/lib/cli/argv.js
@@ -1,9 +1,8 @@
-import Code from '@hapi/code';
+import assert from 'node:assert';
 import Lab from '@hapi/lab';
 import argv from '../../../lib/cli/argv.js';
 const lab = Lab.script();
 export { lab };
-const expect = Code.expect;
 const describe = lab.experiment;
 const it = lab.test;
 const beforeEach = lab.beforeEach;
@@ -12,7 +11,7 @@ const noopProxy = { start: noop };
 describe('argv', function () {
     describe('help', function () {
         const checkForUsage = function (txt) {
-            expect(txt.indexOf('Usage:')).to.equal(0);
+            assert.strictEqual(txt.indexOf('Usage:'), 0);
         };
         it('should print help message with --help', async function () {
             await argv({ _: [], help: true }, checkForUsage, noopProxy);
@@ -24,14 +23,14 @@ describe('argv', function () {
             await argv({ _: [], h: true }, function (txt) {
                 const lines = txt.split('\n');
                 lines.forEach(function (value) {
-                    expect(value.length).to.be.below(81);
+                    assert.ok(value.length < 81);
                 });
             }, noopProxy);
         });
     });
     describe('version', function () {
         const checkForVersion = function (txt) {
-            expect(txt.search(/^\d+\.\d+\.\d+/)).to.equal(0);
+            assert.strictEqual(txt.search(/^\d+\.\d+\.\d+/), 0);
         };
         it('should print the version with --version', async function () {
             await argv({ _: [], version: true }, checkForVersion, noopProxy);
@@ -50,23 +49,23 @@ describe('argv', function () {
         };
         it('should not print anything to stdout with --quiet', async function () {
             await argv({ _: [], quiet: true }, stdoutTestDouble, noopProxy);
-            expect(stdoutWriteCount).to.equal(0);
+            assert.strictEqual(stdoutWriteCount, 0);
         });
         it('should not print anything to stdout with -q', async function () {
             await argv({ _: [], q: true }, stdoutTestDouble, noopProxy);
-            expect(stdoutWriteCount).to.equal(0);
+            assert.strictEqual(stdoutWriteCount, 0);
         });
         it('should print to stdout if no --quiet or -q', async function () {
             await argv({ _: [] }, stdoutTestDouble, noopProxy);
-            expect(stdoutWriteCount).to.be.greaterThan(0);
+            assert.ok(stdoutWriteCount > 0);
         });
     });
     describe('proxy', function () {
         it('should start with defaults if no options specified', async function () {
             const proxyTestDouble = {
                 start: function (port, options) {
-                    expect(port).to.be.undefined();
-                    expect(options).to.equal({});
+                    assert.strictEqual(port, undefined);
+                    assert.deepStrictEqual(options, {});
                 }
             };
             await argv({ _: [] }, noop, proxyTestDouble);
@@ -74,8 +73,8 @@ describe('argv', function () {
         it('should start with options if specified', async function () {
             const proxyTestDouble = {
                 start: function (port, options) {
-                    expect(port).to.equal('9999');
-                    expect(options).to.equal({
+                    assert.strictEqual(port, '9999');
+                    assert.deepStrictEqual(options, {
                         upstream: 'https://example.com:8888',
                         validHttpMethods: ['DELETE', 'PUT'],
                         invalidParams: ['q'],

--- a/test/lib/cli/argv.ts
+++ b/test/lib/cli/argv.ts
@@ -1,13 +1,13 @@
-import type SolrProxy from '../../../index.js'
-import Code from '@hapi/code'
+import assert from 'node:assert'
 
 import Lab from '@hapi/lab'
+
+import type SolrProxy from '../../../index.js'
 
 import argv from '../../../lib/cli/argv.js'
 const lab = Lab.script()
 export { lab }
 
-const expect = Code.expect
 const describe = lab.experiment
 const it = lab.test
 
@@ -19,7 +19,7 @@ const noopProxy = { start: noop }
 describe('argv', function () {
   describe('help', function () {
     const checkForUsage = function (txt: string): void {
-      expect(txt.indexOf('Usage:')).to.equal(0)
+      assert.strictEqual(txt.indexOf('Usage:'), 0)
     }
 
     it('should print help message with --help', async function () {
@@ -34,7 +34,7 @@ describe('argv', function () {
       await argv({ _: [], h: true }, function (txt: string) {
         const lines = txt.split('\n')
         lines.forEach(function (value) {
-          expect(value.length).to.be.below(81)
+          assert.ok(value.length < 81)
         })
       }, noopProxy as typeof SolrProxy)
     })
@@ -42,7 +42,7 @@ describe('argv', function () {
 
   describe('version', function () {
     const checkForVersion = function (txt: string): void {
-      expect(txt.search(/^\d+\.\d+\.\d+/)).to.equal(0)
+      assert.strictEqual(txt.search(/^\d+\.\d+\.\d+/), 0)
     }
 
     it('should print the version with --version', async function () {
@@ -67,17 +67,17 @@ describe('argv', function () {
 
     it('should not print anything to stdout with --quiet', async function () {
       await argv({ _: [], quiet: true }, stdoutTestDouble, noopProxy as typeof SolrProxy)
-      expect(stdoutWriteCount).to.equal(0)
+      assert.strictEqual(stdoutWriteCount, 0)
     })
 
     it('should not print anything to stdout with -q', async function () {
       await argv({ _: [], q: true }, stdoutTestDouble, noopProxy as typeof SolrProxy)
-      expect(stdoutWriteCount).to.equal(0)
+      assert.strictEqual(stdoutWriteCount, 0)
     })
 
     it('should print to stdout if no --quiet or -q', async function () {
       await argv({ _: [] }, stdoutTestDouble, noopProxy as typeof SolrProxy)
-      expect(stdoutWriteCount).to.be.greaterThan(0)
+      assert.ok(stdoutWriteCount > 0)
     })
   })
 
@@ -85,8 +85,8 @@ describe('argv', function () {
     it('should start with defaults if no options specified', async function () {
       const proxyTestDouble = {
         start: function (port: any, options: any) {
-          expect(port).to.be.undefined()
-          expect(options).to.equal({})
+          assert.strictEqual(port, undefined)
+          assert.deepStrictEqual(options, {})
         }
       }
       await argv({ _: [] }, noop, proxyTestDouble as typeof SolrProxy)
@@ -95,8 +95,8 @@ describe('argv', function () {
     it('should start with options if specified', async function () {
       const proxyTestDouble = {
         start: function (port: any, options: any) {
-          expect(port).to.equal('9999')
-          expect(options).to.equal({
+          assert.strictEqual(port, '9999')
+          assert.deepStrictEqual(options, {
             upstream: 'https://example.com:8888',
             validHttpMethods: ['DELETE', 'PUT'],
             invalidParams: ['q'],


### PR DESCRIPTION
We're not using it for anything we can't get easily from assert.