### PR TITLE
chore: replace deprecated function signature

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ const SolrProxy = {
         const options = Object.assign(defaultOptions, userOptions);
         port = +port > 0 ? +port : options.listenPort;
         const server = await createServer(options);
-        await server.listen(port);
+        await server.listen({ port });
         return server;
     }
 };

--- a/index.ts
+++ b/index.ts
@@ -115,7 +115,7 @@ const SolrProxy = {
     port = +port > 0 ? +port : options.listenPort
 
     const server = await createServer(options)
-    await server.listen(port)
+    await server.listen({ port })
     return server
   }
 }


### PR DESCRIPTION
fastify@5 will remove the variadic signature for `listen()`. Switch to
the supported signature.